### PR TITLE
fix: Fix useless background on hover applied separately on blocks sender, timestamp, subject and content - EXO-82155 - exoplatform/eXIP#26

### DIFF
--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItem.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItem.vue
@@ -16,11 +16,15 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
   <v-hover v-slot="{ hover }">
-    <v-list :class="{ 'light-grey-background-color': hover }">
+    <div
+      role="button"
+      tabindex="0"
+      :class="{'light-grey-background-color': hover}"
+      @click="openDetail"
+      @keydown.enter="openDetail">
       <v-list-item
         style="min-height: 0"
-        class="px-0 pb-2"
-        @click="openDetail"> 
+        class="px-0 pb-2"> 
         <v-list-item-content class="py-0">
           <v-list-item-title v-text="email.sender.name" />
         </v-list-item-content>
@@ -30,14 +34,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       </v-list-item>
       <v-list-item
         style="min-height: 0"
-        class="px-0"
-        @click="openDetail">
+        class="px-0">
         <v-list-item-content class="py-0">
           <v-list-item-subtitle class="mb-1 text-color" v-text="email.subject" />
           <v-list-item-subtitle v-text="email.content" />
         </v-list-item-content>
       </v-list-item>
-    </v-list>
+    </div>
   </v-hover>
 </template>
 


### PR DESCRIPTION
Prior to this change, a useless hover is applied separately on sender, timestamp, subject and content blocks in addition to the global hover applied on the whole email list item block. After this commit, the html structure is changed to avoid this useless hover and keep only the global hover. 