### PR TITLE
fix: Fix displaying images into email detail - EXO-82197 - exoplatform/eXIP#26

### DIFF
--- a/email-connector-services/src/main/java/org/exoplatform/emailConnector/utils/EmailConnectorUtils.java
+++ b/email-connector-services/src/main/java/org/exoplatform/emailConnector/utils/EmailConnectorUtils.java
@@ -12,9 +12,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import javax.activation.DataHandler;
 import javax.imageio.ImageIO;
 import javax.mail.Address;
 import javax.mail.BodyPart;
@@ -78,7 +81,7 @@ public class EmailConnectorUtils {
       content = Jsoup.parse(content).text().trim();
       return content.length() > 50 ? content.substring(0, 50) + "..." : content;
     } else
-      return Jsoup.parse(content).body().html().trim();
+      return content.trim();
   }
 
   public static int getEmailBoxUserSyncPeriod(UserEmailSetting userEmailSetting) {
@@ -153,17 +156,27 @@ public class EmailConnectorUtils {
   }
 
   private static String getHtmlFromMimeMultipart(MimeMultipart mimeMultipart) throws MessagingException, IOException {
+    StringBuilder htmlContent = new StringBuilder();
+    Map<String, String> cidImageMap = new HashMap<>();
     for (int i = 0; i < mimeMultipart.getCount(); i++) {
       BodyPart bodyPart = mimeMultipart.getBodyPart(i);
       if (bodyPart.isMimeType("text/html")) {
-        return safeGetContent(bodyPart);
-      } else if (bodyPart.getContent() instanceof MimeMultipart) {
-        String result = getHtmlFromMimeMultipart((MimeMultipart) bodyPart.getContent());
-        if (!result.isEmpty())
-          return result;
+        htmlContent.append(safeGetContent(bodyPart));
+      } else if (bodyPart.isMimeType("multipart/alternative") || bodyPart.getContent() instanceof MimeMultipart) {
+        htmlContent.append(getHtmlFromMimeMultipart((MimeMultipart) bodyPart.getContent()));
+      } else if (Part.ATTACHMENT.equalsIgnoreCase(bodyPart.getDisposition()) || bodyPart.isMimeType("image/*")) {
+        String cid = getCid(bodyPart);
+        if (cid != null) {
+          cidImageMap.put(cid, encodeToBase64DataUrl(bodyPart));
+        }
       }
     }
-    return "";
+    String finalHtml = htmlContent.toString();
+    for (Map.Entry<String, String> entry : cidImageMap.entrySet()) {
+      finalHtml = finalHtml.replace("cid:" + entry.getKey(), entry.getValue());
+    }
+
+    return finalHtml;
   }
 
   private static Profile getUserProfileByEmail(String email) {
@@ -239,4 +252,26 @@ public class EmailConnectorUtils {
       return null;
     }
   }
+
+  private static String getCid(BodyPart bodyPart) throws MessagingException {
+    String[] cids = bodyPart.getHeader("Content-ID");
+    if (cids != null && cids.length > 0) {
+      return cids[0].replaceAll("[<>]", "");
+    }
+    return null;
+  }
+
+  private static String encodeToBase64DataUrl(BodyPart bodyPart) {
+    try {
+        DataHandler handler = bodyPart.getDataHandler();
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        handler.writeTo(os);
+        byte[] bytes = os.toByteArray();
+        String base64 = Base64.getEncoder().encodeToString(bytes);
+        String mimeType = bodyPart.getContentType().split(";")[0].trim();
+        return "data:" + mimeType + ";base64," + base64;
+    } catch (Exception e) {
+        return "";
+    }
+}
 }

--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemDetail.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemDetail.vue
@@ -42,7 +42,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           <v-list-item
             style="min-height: 0"
             :class="recipientsClass">
-            <email-connector-mail-box-drawer-list-item-detail-sender-avatar :email="email" class="me-3 my-0" />
+            <email-connector-mail-box-drawer-list-item-detail-sender-avatar 
+              :email="email" 
+              class="me-3 my-0" />
             <v-list-item-content class="py-0">
               <v-list-item-title class="font-weight-bold mb-3" v-text="email.sender.name" />
               <v-list-item-subtitle class="text-wrap overflow-visible d-flex align-center">
@@ -61,8 +63,12 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
               <v-list-item-subtitle v-text="sentDate" />
             </v-list-item-action>
           </v-list-item>
-          <email-connector-mail-box-drawer-list-item-detail-header v-if="expandedHeader" :email="email" />
-          <email-connector-mail-box-drawer-list-item-detail-body :expanded-drawer="expandedDrawer" :email-content="email.content" />
+          <email-connector-mail-box-drawer-list-item-detail-header 
+            v-if="expandedHeader"
+            :email="email" />
+          <email-connector-mail-box-drawer-list-item-detail-body 
+            :expanded-drawer="expandedDrawer" 
+            :email-content="email.content" />
         </v-list>
       </div>
     </template>

--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemDetailBody.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemDetailBody.vue
@@ -26,8 +26,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       height: iframeHeight + 'px'
     }"
     @load="onLoadIframe"
-    title="email-body"
-  ></iframe>
+    title="email-body"></iframe>
 </template>
 
 <script>
@@ -75,7 +74,19 @@ export default {
       const responsiveCSS = `
         * { max-width: 100% !important; box-sizing: border-box !important; }
         table { width: 100% !important; height: auto !important; }
+        td, th { word-break: break-word !important; }
         img { max-width: 100% !important; height: auto !important; display:block; }
+        pre {
+          white-space: pre-wrap !important;
+          word-wrap: break-word !important;
+          direction: auto !important;
+          text-align: right !important;
+          overflow: visible !important;
+        }
+        [dir="RTL"], [dir="rtl"] {
+          direction: rtl !important;
+          text-align: right !important;
+        }
       `;
       const finalCSS = this.expandedDrawer ? baseCSS : baseCSS + responsiveCSS;
       return `


### PR DESCRIPTION
Prior to this change, when opening email detail containing images, the images are not displayed. It is caused by the src of the images pointing on email server internal urls which are not well accessed.
After this commit, the content of images are extracted from cid content-id and built with Base64 data Urls in order to be well displayed. 