### PR TITLE
fix: Fix bad alignment of "To" recipients block when email is long - EXO-82201 - exoplatform/eXIP#26

### DIFF
--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemDetail.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemDetail.vue
@@ -48,7 +48,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             <v-list-item-content class="py-0">
               <v-list-item-title class="font-weight-bold mb-3" v-text="email.sender.name" />
               <v-list-item-subtitle class="text-wrap overflow-visible d-flex align-center">
-                <span class="me-1">{{ recipients }}</span>
+                <span class="me-1 text-wrap text-break-all">{{ recipients }}</span>
                 <v-btn
                   @click="toggleDetails()"
                   width="20"


### PR DESCRIPTION
Prior to this change when some emails in the To" recipients block are long, the block is not well vertically aligned. 
To fix that we have enabled the text wrapping and word breaking for long email addresses.