### PR TITLE
fix: Hide email user setting when user notification settings are displayed - EXO-82333 - exoplatform/eXIP#27

### DIFF
--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-user-setting/components/EmailConnectorUserSettingApp.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-user-setting/components/EmailConnectorUserSettingApp.vue
@@ -36,23 +36,38 @@ export default {
       emailConnectorIcon: '',
       emailAddress: '',
       emailPassword: ''
-    }
+    },
+    displayed: true,
   }),
+  watch: {
+    displayed() {
+      this.$root.$updateApplicationVisibility(this.displayed);
+    },
+  },
   mounted() {
     document.addEventListener('refresh-user-email-setting', this.getUserEmailSetting);
+    this.$root.$updateApplicationVisibility(this.displayed);
   },
   beforeDestroy() {
     document.removeEventListener('refresh-user-email-setting', this.getUserEmailSetting);
   },
   created() {
     this.getUserEmailSetting();
+    document.addEventListener('showSettingsApps', this.showSettingsApps);
+    document.addEventListener('hideSettingsApps', this.hideSettingsApps);
   },
   methods: {
     getUserEmailSetting() {
       this.$emailConnectorCommonService.getUserEmailSetting().then(userEmailSetting => {
         this.userEmailSetting = userEmailSetting;
       });
-    }
+    },
+    hideSettingsApps() {
+      this.displayed = false;
+    },
+    showSettingsApps() {
+      this.displayed = true;
+    },
   }
 };
 </script>


### PR DESCRIPTION
Prior to this change, when the user notification settings are displayed, the email user setting is displayed also.
After this commit, we ensurre to hide the email user setting block when user notification settings are displayed in order to have a coherent UI/UX with other user setting blocks.