### PR TITLE
fix: Fix error when synchronizing email with long receiver, cc or bcc fields - EXO-83930

### DIFF
--- a/email-connector-services/src/main/java/org/exoplatform/emailConnector/dao/EmailBoxDAO.java
+++ b/email-connector-services/src/main/java/org/exoplatform/emailConnector/dao/EmailBoxDAO.java
@@ -28,11 +28,11 @@ import org.exoplatform.emailConnector.entity.EmailBoxEntity;
 
 public interface EmailBoxDAO extends JpaRepository<EmailBoxEntity, Long> {
 
-  @Query("SELECT email FROM EmailBoxEntity email LEFT JOIN FETCH email.attachments WHERE email.userId = :username ORDER BY email.recievedDate DESC")
+  @Query("SELECT email FROM EmailBoxEntity email LEFT JOIN FETCH email.attachments WHERE email.userId = :username ORDER BY email.receivedDate DESC")
   List<EmailBoxEntity> findByUserIdWithAttachments(@Param("username")
   String username);
 
-  @Query("SELECT email FROM EmailBoxEntity email LEFT JOIN FETCH email.attachments WHERE email.userId = :username AND email.mailRemoteId = :mailRemoteId ORDER BY email.recievedDate DESC")
+  @Query("SELECT email FROM EmailBoxEntity email LEFT JOIN FETCH email.attachments WHERE email.userId = :username AND email.mailRemoteId = :mailRemoteId ORDER BY email.receivedDate DESC")
   EmailBoxEntity findByMailRemoteIdAndUserId(@Param("mailRemoteId")
   long mailRemoteId, @Param("username")
   String userId);

--- a/email-connector-services/src/main/java/org/exoplatform/emailConnector/entity/EmailBoxEntity.java
+++ b/email-connector-services/src/main/java/org/exoplatform/emailConnector/entity/EmailBoxEntity.java
@@ -60,7 +60,7 @@ public class EmailBoxEntity {
   @Column(name = "SENDER")
   private String                      sender;
 
-  @Column(name = "RECIEVER")
+  @Column(name = "RECEIVER")
   private String                      to;
 
   @Column(name = "CC")
@@ -69,8 +69,8 @@ public class EmailBoxEntity {
   @Column(name = "BCC")
   private String                      bcc;
 
-  @Column(name = "RECIEVED_DATE")
-  private Date                        recievedDate;
+  @Column(name = "RECEIVED_DATE")
+  private Date                        receivedDate;
 
   @Column(name = "IS_READ")
   private boolean                     read;

--- a/email-connector-services/src/main/java/org/exoplatform/emailConnector/model/Email.java
+++ b/email-connector-services/src/main/java/org/exoplatform/emailConnector/model/Email.java
@@ -38,7 +38,7 @@ public class Email {
 
   private EmailContent         content;
 
-  private Date                 recievedDate;
+  private Date                 receivedDate;
 
   private EmailSender          sender;
 

--- a/email-connector-services/src/main/java/org/exoplatform/emailConnector/notification/plugin/NewEmailsNotificationPlugin.java
+++ b/email-connector-services/src/main/java/org/exoplatform/emailConnector/notification/plugin/NewEmailsNotificationPlugin.java
@@ -32,7 +32,7 @@ import org.exoplatform.services.resources.ResourceBundleService;
 public class NewEmailsNotificationPlugin extends BaseNotificationPlugin {
 
   public static final ArgumentLiteral<String> RECEIVER                  =
-                                                       new ArgumentLiteral<>(String.class, "reciever");
+                                                       new ArgumentLiteral<>(String.class, "receiver");
 
   public static final ArgumentLiteral<String> NEW_EMAILS                = new ArgumentLiteral<>(String.class, "newEmails");
 

--- a/email-connector-services/src/main/java/org/exoplatform/emailConnector/storage/EmailBoxStorage.java
+++ b/email-connector-services/src/main/java/org/exoplatform/emailConnector/storage/EmailBoxStorage.java
@@ -117,7 +117,7 @@ public class EmailBoxStorage {
                                                          toRecipientsString(email.getTo()),
                                                          toRecipientsString(email.getCc()),
                                                          toRecipientsString(email.getBcc()),
-                                                         email.getRecievedDate(),
+                                                         email.getReceivedDate(),
                                                          email.isRead(),
                                                          null);
       List<EmailAttachmentEntity> attachments = email.getContent() != null
@@ -155,7 +155,7 @@ public class EmailBoxStorage {
                               emailBoxEntity.getUserId(),
                               emailBoxEntity.getSubject(),
                               new EmailContent(emailBoxEntity.getBody(), excerpt, attachments),
-                              emailBoxEntity.getRecievedDate(),
+                              emailBoxEntity.getReceivedDate(),
                               EmailConnectorUtils.getEmailSender(emailSenderAddress, withProfile),
                               emailBoxEntity.isRead(),
                               null,

--- a/email-connector-services/src/main/resources/db/changelog/emailConnector-rdbms.db.changelog-master.xml
+++ b/email-connector-services/src/main/resources/db/changelog/emailConnector-rdbms.db.changelog-master.xml
@@ -125,4 +125,28 @@
       <column name="BCC" type="VARCHAR(1024)"/>
     </addColumn>
   </changeSet>
+  <changeSet author="email-connector" id="1.0.0-9">
+     <modifyDataType 
+      tableName="EMAIL_BOX" 
+      columnName="RECIEVER" 
+      newDataType="LONGTEXT" />
+     <modifyDataType 
+      tableName="EMAIL_BOX" 
+      columnName="CC" 
+      newDataType="LONGTEXT" />
+     <modifyDataType 
+      tableName="EMAIL_BOX" 
+      columnName="BCC" 
+      newDataType="LONGTEXT" />
+    <renameColumn
+      tableName="EMAIL_BOX"
+      oldColumnName="RECIEVED_DATE"
+      newColumnName="RECEIVED_DATE" 
+      columnDataType="TIMESTAMP" />
+    <renameColumn
+      tableName="EMAIL_BOX"
+      oldColumnName="RECIEVER"
+      newColumnName="RECEIVER"
+      columnDataType="LONGTEXT" />
+  </changeSet>
 </databaseChangeLog>

--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItem.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItem.vue
@@ -83,7 +83,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             <v-list-item-title v-text="email.sender.name" />
           </v-list-item-content>
           <v-list-item-action class="my-0">
-            <v-list-item-subtitle v-text="recievedDate" />
+            <v-list-item-subtitle v-text="receivedDate" />
           </v-list-item-action>
         </v-list-item>
         <v-list-item
@@ -131,8 +131,8 @@ export default {
     gapSize() {
       return Math.abs(this.left);
     },
-    recievedDate() {
-      return this.$emailConnectorMailBoxService.formatDateString(this.email.recievedDate, this.$t('emailConnector.mailBox.list.drawer.yesterday'));
+    receivedDate() {
+      return this.$emailConnectorMailBoxService.formatDateString(this.email.receivedDate, this.$t('emailConnector.mailBox.list.drawer.yesterday'));
     },
     isMobile() {
       return this.$vuetify.breakpoint.smAndDown;

--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemDetail.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemDetail.vue
@@ -92,7 +92,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
               </v-list-item-subtitle>
             </v-list-item-content>
             <v-list-item-action class="my-0 align-self-start">
-              <v-list-item-subtitle v-text="recievedDate" />
+              <v-list-item-subtitle v-text="receivedDate" />
             </v-list-item-action>
           </v-list-item>
           <email-connector-mail-box-drawer-list-item-detail-header 
@@ -134,8 +134,8 @@ export default {
     });
   },
   computed: {
-    recievedDate() {
-      return this.$emailConnectorMailBoxService.formatDateString(this.email.recievedDate, this.$t('emailConnector.mailBox.list.drawer.yesterday'));
+    receivedDate() {
+      return this.$emailConnectorMailBoxService.formatDateString(this.email.receivedDate, this.$t('emailConnector.mailBox.list.drawer.yesterday'));
     },
     chevronIcon() {
       return this.expandedHeader ? 'fa-chevron-up' : 'fa-chevron-down';


### PR DESCRIPTION

Prior to this change, when synchronizing emails with long receiver, cc or bcc fields, an error MysqlDataTruncation is generated. This is due to the type VARCHAR(1024) of these fields in EMAIL_BOX table which is not sufficient when long text cases. After this commit, we will change the type of these fields to LONGTEXT in order to allow them store any long text.