### PR TITLE
fix: Fix long sender not truncated in email list - EXO-84706 - exoplatform/eXIP#34

### DIFF
--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItem.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItem.vue
@@ -74,7 +74,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         :input-value="selected"
         @click.stop
         @change="onSelectChange" />
-      <div class="flex-grow-1">    
+      <div class="flex-grow-1 no-min-width">    
         <div
           role="button"
           tabindex="0"


### PR DESCRIPTION

Prior to this change when the sender is long in email list, it is not truncated and displayed without ellipsis. After this commit, we have set `min-width: 0` on the flex-grow wrapper to enable proper flexbox shrinking and restore ellipsis behavior.