### PR TITLE
fix: Fix flickering effect on email list when hovering over an email without subject - EXO-85174

### DIFF
--- a/email-connector-webapps/src/main/resources/locale/portlet/emailConnector/emailConnectorMailBox_en.properties
+++ b/email-connector-webapps/src/main/resources/locale/portlet/emailConnector/emailConnectorMailBox_en.properties
@@ -1,6 +1,7 @@
 emailConnector.mailBox.list.drawer.title=Email
 emailConnector.mailBox.list.drawer.noEmail=No email
 emailConnector.mailBox.list.drawer.emptyEmail=The body is empty
+emailConnector.mailBox.list.drawer.noSubject=(no subject)
 emailConnector.mailBox.list.drawer.emailSelected=selected
 emailConnector.mailBox.list.drawer.emailsSelected=selected
 emailConnector.mailBox.list.drawer.selectAll=Select all

--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItem.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItem.vue
@@ -101,7 +101,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           <v-list-item
             class="px-0 height-auto">
             <v-list-item-content class="py-0">
-              <v-list-item-subtitle :class="['mb-1 text-color', { 'font-weight-bold': !email.read }]" v-text="email.subject" />
+              <v-list-item-subtitle :class="['mb-1 text-color', { 'font-weight-bold': !email.read }]" v-text="subject" />
               <v-list-item-subtitle v-text="excerpt" />
             </v-list-item-content>
             <email-connector-mail-box-drawer-list-item-action-menu
@@ -179,6 +179,9 @@ export default {
     },
     excerpt() {
       return this.email.content?.excerpt || this.$t('emailConnector.mailBox.list.drawer.emptyEmail');
+    },
+    subject() {
+      return this.email.subject || this.$t('emailConnector.mailBox.list.drawer.noSubject');
     },
   },
   methods: {


### PR DESCRIPTION

Prior to this change, when hovering over an email without subject, we have a flickering effect on email list. To fix that behavior, we will display the default subject "no subject" for emails not having a subject.