### PR TITLE
fix: Fix loss of "to", "cc", and "bcc" fields after synchronization - EXO-86140

### DIFF
--- a/email-connector-services/src/main/java/org/exoplatform/emailConnector/dao/EmailBoxDAO.java
+++ b/email-connector-services/src/main/java/org/exoplatform/emailConnector/dao/EmailBoxDAO.java
@@ -28,13 +28,13 @@ import org.exoplatform.emailConnector.entity.EmailBoxEntity;
 
 public interface EmailBoxDAO extends JpaRepository<EmailBoxEntity, Long> {
 
-  @Query("SELECT email FROM EmailBoxEntity email LEFT JOIN FETCH email.attachments WHERE email.userId = :username ORDER BY email.receivedDate DESC")
-  List<EmailBoxEntity> findByUserIdWithAttachments(@Param("username")
-  String username);
+  @Query("SELECT email FROM EmailBoxEntity email LEFT JOIN FETCH email.attachments WHERE email.userId = :userId ORDER BY email.receivedDate DESC")
+  List<EmailBoxEntity> findByUserIdWithAttachments(@Param("userId")
+  String userId);
 
-  @Query("SELECT email FROM EmailBoxEntity email LEFT JOIN FETCH email.attachments WHERE email.userId = :username AND email.mailRemoteId = :mailRemoteId ORDER BY email.receivedDate DESC")
+  @Query("SELECT email FROM EmailBoxEntity email LEFT JOIN FETCH email.attachments WHERE email.userId = :userId AND email.mailRemoteId = :mailRemoteId ORDER BY email.receivedDate DESC")
   EmailBoxEntity findByMailRemoteIdAndUserId(@Param("mailRemoteId")
-  long mailRemoteId, @Param("username")
+  long mailRemoteId, @Param("userId")
   String userId);
 
   void deleteByUserId(String userId);
@@ -47,10 +47,17 @@ public interface EmailBoxDAO extends JpaRepository<EmailBoxEntity, Long> {
 
   @Transactional
   @Modifying
-  @Query("UPDATE EmailBoxEntity email SET email.read = :readStatus WHERE email.mailRemoteId IN :mailRemoteIds AND email.userId = :username AND (email.read IS NULL OR email.read <> :readStatus)")
+  @Query("UPDATE EmailBoxEntity email SET email.read = :readStatus WHERE email.mailRemoteId IN :mailRemoteIds AND email.userId = :userId AND (email.read IS NULL OR email.read <> :readStatus)")
   void updateReadStatusByMailRemoteIds(@Param("mailRemoteIds")
-  List<Long> mailRemoteIds, @Param("username")
-  String username, @Param("readStatus")
+  List<Long> mailRemoteIds, @Param("userId")
+  String userId, @Param("readStatus")
   boolean readStatus);
+
+  @Transactional
+  @Modifying
+  @Query("UPDATE EmailBoxEntity email SET email.recent = false WHERE email.mailRemoteId = :mailRemoteId AND email.userId = :userId")
+  void markEmailAsNotRecent(@Param("mailRemoteId")
+  Long mailRemoteId, @Param("userId")
+  String userId);
 
 }

--- a/email-connector-services/src/main/java/org/exoplatform/emailConnector/service/EmailBoxService.java
+++ b/email-connector-services/src/main/java/org/exoplatform/emailConnector/service/EmailBoxService.java
@@ -370,9 +370,7 @@ public class EmailBoxService {
               remoteMessage.setFlag(Flags.Flag.SEEN, readStatus);
             }
           } catch (Exception e) {
-            Email email = getEmailByMailRemoteIdAndUserId(mailRemoteId, username, false, false, false, false);
-            email.setRead(!readStatus);
-            emailBoxStorage.updateEmail(email);
+            emailBoxStorage.updateEmailReadStatusByMailRemoteIds(List.of(mailRemoteId), username, !readStatus);
             LOG.error("Error when updating email {} read status for user {}", mailRemoteId, username, e);
           }
         }
@@ -693,8 +691,7 @@ public class EmailBoxService {
 
         } else {
           updateEmailReadStatus(List.of(messageUid), username, message.isSet(Flags.Flag.SEEN), false);
-          email.setRecent(false);
-          emailBoxStorage.updateEmail(email);
+          emailBoxStorage.markEmailAsNotRecent(messageUid, username);
         }
       } catch (Exception e) {
         LOG.warn("Error when storing email with subject {} for user {}", message.getSubject(), username, e);

--- a/email-connector-services/src/main/java/org/exoplatform/emailConnector/storage/EmailBoxStorage.java
+++ b/email-connector-services/src/main/java/org/exoplatform/emailConnector/storage/EmailBoxStorage.java
@@ -27,7 +27,6 @@ import org.jsoup.Jsoup;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.emailConnector.dao.EmailAttachmentDAO;
 import org.exoplatform.emailConnector.dao.EmailBoxDAO;
 import org.exoplatform.emailConnector.entity.EmailAttachmentEntity;
@@ -68,12 +67,8 @@ public class EmailBoxStorage {
     return fromEntity(emailBoxEntity, false, false, null, true, false);
   }
 
-  public void updateEmail(Email email) {
-    if (email == null) {
-      throw new IllegalArgumentException("email is mandatory");
-    }
-    EmailBoxEntity emailBoxEntity = toEntity(email);
-    emailBoxDao.save(emailBoxEntity);
+  public void markEmailAsNotRecent(Long mailRemoteId, String userId) {
+    emailBoxDao.markEmailAsNotRecent(mailRemoteId, userId);
   }
 
   public void updateEmailReadStatusByMailRemoteIds(List<Long> mailRemoteIds, String userId, boolean readStatus) {
@@ -94,11 +89,9 @@ public class EmailBoxStorage {
     return fromEntity(emailBoxEntity, true, false, userId, true, true);
   }
 
-  public List<Email> getEmails(String username) {
-    List<EmailBoxEntity> emailBoxEntities = emailBoxDao.findByUserIdWithAttachments(username);
-    return emailBoxEntities.stream()
-                           .map(emailBoxEntity -> fromEntity(emailBoxEntity, true, true, username, false, false))
-                           .toList();
+  public List<Email> getEmails(String userId) {
+    List<EmailBoxEntity> emailBoxEntities = emailBoxDao.findByUserIdWithAttachments(userId);
+    return emailBoxEntities.stream().map(emailBoxEntity -> fromEntity(emailBoxEntity, true, true, userId, false, false)).toList();
   }
 
   public void deleteEmailsByIds(List<Long> emailsIds) {

--- a/email-connector-services/src/test/java/org/exoplatform/emailConnector/storage/EmailBoxStorageTest.java
+++ b/email-connector-services/src/test/java/org/exoplatform/emailConnector/storage/EmailBoxStorageTest.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.emailConnector.storage;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -24,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
@@ -77,8 +79,6 @@ public class EmailBoxStorageTest {
       EmailBoxEntity entity = invocation.getArgument(0);
       if (entity.getId() == null) {
         entity.setId(ID);
-      } else {
-        entity.setSubject(entity.getSubject() + " (updated)");
       }
       when(emailBoxDAO.findByUserIdWithAttachments("root")).thenReturn(Optional.of(entity)
                                                                                .stream()
@@ -109,6 +109,14 @@ public class EmailBoxStorageTest {
       }
       return null;
     }).when(emailBoxDAO).updateReadStatusByMailRemoteIds(anyList(), anyString(), anyBoolean());
+
+    doAnswer(invocation -> {
+      EmailBoxEntity entity = emailBoxDAO.findByMailRemoteIdAndUserId(1212L, "root");
+      if (entity != null) {
+        entity.setRecent(false);
+      }
+      return null;
+    }).when(emailBoxDAO).markEmailAsNotRecent(anyLong(), anyString());
   }
 
   @Test
@@ -122,13 +130,13 @@ public class EmailBoxStorageTest {
   }
 
   @Test
-  void updateEmail() {
+  void markEmailAsNotRecent() {
     Email email = email("root");
-    Email createdEmail = emailBoxStorage.createEmail(email);
-    emailBoxStorage.updateEmail(createdEmail);
+    emailBoxStorage.createEmail(email);
+    emailBoxStorage.markEmailAsNotRecent(1212l, "root");
     Email updatedEmail = emailBoxStorage.getEmailByMailRemoteIdAndUserId(1212l, "root", false, false, false);
     assertNotNull(updatedEmail);
-    assertEquals("subject (updated)", updatedEmail.getSubject());
+    assertFalse(updatedEmail.isRecent());
   }
 
   @Test


### PR DESCRIPTION

Prior to this change, after synchronization, the "to", "cc", and "bcc" fields are lost. This issue was caused by using a generic email update method to set the "recent" field to false for existing emails. This method updated the entire Email entity but did not include the "to", "cc", and "bcc" fields, leading to them being overwritten with null values. After this change, a dedicated method is used to update only the "recent" field, preventing unintended overwrites of other fields.