### PR TITLE
fix: Fix "reply all" cc addresses must exclude connected email address instead of user account email - EXO-86449

### DIFF
--- a/email-connector-services/src/main/java/org/exoplatform/emailConnector/service/EmailBoxService.java
+++ b/email-connector-services/src/main/java/org/exoplatform/emailConnector/service/EmailBoxService.java
@@ -313,7 +313,7 @@ public class EmailBoxService {
     }
   }
 
-  public void broadcastOpenEmail(String username) throws IllegalAccessException {
+  public String broadcastOpenEmail(String username) throws IllegalAccessException {
     UserEmailSetting userEmailSetting = userEmailSettingService.getUserEmailSetting(username);
     if (userEmailSetting.getEmailConnectorId() == null
         || !userEmailSettingService.canConnect(Long.parseLong(userEmailSetting.getEmailConnectorId()), username)) {
@@ -325,6 +325,7 @@ public class EmailBoxService {
       LOG.warn("Error broadcasting event '" + EmailConnectorUtils.OPEN_EMAIL + "' using source '" + username + "' and data "
           + userEmailSetting.getEmailConnectorName(), e);
     }
+    return userEmailSetting.getEmailAddress();
   }
 
   public Email getEmailByMailRemoteIdAndUserId(long mailRemoteId,
@@ -333,15 +334,22 @@ public class EmailBoxService {
                                                boolean withRecipients,
                                                boolean withProfile,
                                                boolean broadcast) throws IllegalAccessException {
+    String userEmail = null;
     if (broadcast) {
-      broadcastOpenEmail(username);
+      userEmail = broadcastOpenEmail(username);
     }
-    return emailBoxStorage.getEmailByMailRemoteIdAndUserId(mailRemoteId, username, withAttachments, withRecipients, withProfile);
+    return emailBoxStorage.getEmailByMailRemoteIdAndUserId(mailRemoteId,
+                                                           username,
+                                                           userEmail,
+                                                           withAttachments,
+                                                           withRecipients,
+                                                           withProfile);
   }
 
   @Transactional
   public Email getEmailById(long id, String username) {
-    return emailBoxStorage.getEmailById(id, username);
+    UserEmailSetting userEmailSetting = userEmailSettingService.getUserEmailSetting(username);
+    return emailBoxStorage.getEmailById(id, username, userEmailSetting.getEmailAddress());
   }
 
   public void updateEmailReadStatus(List<Long> mailRemoteIds,

--- a/email-connector-services/src/main/java/org/exoplatform/emailConnector/storage/EmailBoxStorage.java
+++ b/email-connector-services/src/main/java/org/exoplatform/emailConnector/storage/EmailBoxStorage.java
@@ -37,9 +37,6 @@ import org.exoplatform.emailConnector.model.EmailContent;
 import org.exoplatform.emailConnector.model.EmailRecipient;
 import org.exoplatform.emailConnector.plugin.EmailCategoryPlugin;
 import org.exoplatform.emailConnector.utils.EmailConnectorUtils;
-import org.exoplatform.social.core.identity.model.Identity;
-import org.exoplatform.social.core.identity.model.Profile;
-import org.exoplatform.social.core.manager.IdentityManager;
 
 import io.meeds.social.category.model.CategoryObject;
 import io.meeds.social.category.service.CategoryLinkService;
@@ -61,16 +58,13 @@ public class EmailBoxStorage {
   @Autowired
   private CategoryLinkService categoryLinkService;
 
-  @Autowired
-  private IdentityManager     identityManager;
-
   public Email createEmail(Email email) {
     if (email == null) {
       throw new IllegalArgumentException("email is mandatory");
     }
     EmailBoxEntity emailBoxEntity = toEntity(email);
     emailBoxEntity = emailBoxDao.save(emailBoxEntity);
-    return fromEntity(emailBoxEntity, false, false, null, true, false);
+    return fromEntity(emailBoxEntity, false, false, null, null, true, false);
   }
 
   public void markEmailAsNotRecent(Long mailRemoteId, String userId) {
@@ -83,21 +77,24 @@ public class EmailBoxStorage {
 
   public Email getEmailByMailRemoteIdAndUserId(long mailRemoteId,
                                                String userId,
+                                               String userEmail,
                                                boolean withAttachments,
                                                boolean withRecipients,
                                                boolean withProfile) {
     EmailBoxEntity emailBoxEntity = emailBoxDao.findByMailRemoteIdAndUserId(mailRemoteId, userId);
-    return fromEntity(emailBoxEntity, withAttachments, false, userId, withRecipients, withProfile);
+    return fromEntity(emailBoxEntity, withAttachments, false, userId, userEmail, withRecipients, withProfile);
   }
 
-  public Email getEmailById(long id, String userId) {
+  public Email getEmailById(long id, String userId, String userEmail) {
     EmailBoxEntity emailBoxEntity = emailBoxDao.findById(id).orElse(null);
-    return fromEntity(emailBoxEntity, true, false, userId, true, true);
+    return fromEntity(emailBoxEntity, true, false, userId, userEmail, true, true);
   }
 
   public List<Email> getEmails(String userId) {
     List<EmailBoxEntity> emailBoxEntities = emailBoxDao.findByUserIdWithAttachments(userId);
-    return emailBoxEntities.stream().map(emailBoxEntity -> fromEntity(emailBoxEntity, true, true, userId, false, false)).toList();
+    return emailBoxEntities.stream()
+                           .map(emailBoxEntity -> fromEntity(emailBoxEntity, true, true, userId, null, false, false))
+                           .toList();
   }
 
   public void deleteEmailsByIds(List<Long> emailsIds) {
@@ -148,6 +145,7 @@ public class EmailBoxStorage {
                            boolean withAttachments,
                            boolean isExcerpt,
                            String userId,
+                           String userEmail,
                            boolean withRecipients,
                            boolean withProfile) {
     if (emailBoxEntity == null) {
@@ -167,12 +165,11 @@ public class EmailBoxStorage {
       List<Long> categoryIds = categoryLinkService.getLinkedIds(new CategoryObject(EmailCategoryPlugin.OBJECT_TYPE,
                                                                                    String.valueOf(emailBoxEntity.getId()),
                                                                                    0));
-      Identity currentIdentity = identityManager.getOrCreateUserIdentity(userId);
       Email email = new Email(emailBoxEntity.getId(),
                               emailBoxEntity.getMailRemoteId(),
                               emailBoxEntity.getMailHeaderId(),
                               emailBoxEntity.getUserId(),
-                              currentIdentity != null ? currentIdentity.getProfile().getEmail() : null,
+                              userEmail,
                               emailBoxEntity.getSubject(),
                               new EmailContent(emailBoxEntity.getBody(), excerpt, attachments),
                               emailBoxEntity.getReceivedDate(),

--- a/email-connector-services/src/test/java/org/exoplatform/emailConnector/service/EmailBoxServiceTest.java
+++ b/email-connector-services/src/test/java/org/exoplatform/emailConnector/service/EmailBoxServiceTest.java
@@ -175,13 +175,15 @@ public class EmailBoxServiceTest {
   @Test
   void getEmailByMailRemoteIdAndUserId() throws IllegalAccessException {
     emailBoxService.getEmailByMailRemoteIdAndUserId(1212l, TEST_USER, false, false, false, false);
-    verify(emailBoxStorage).getEmailByMailRemoteIdAndUserId(1212l, TEST_USER, false, false, false);
+    verify(emailBoxStorage).getEmailByMailRemoteIdAndUserId(1212l, TEST_USER, null, false, false, false);
   }
 
   @Test
   void getEmailById() {
+    UserEmailSetting userEmailSetting = userEmailSetting();
+    when(userEmailSettingService.getUserEmailSetting(TEST_USER)).thenReturn(userEmailSetting);
     emailBoxService.getEmailById(121l, TEST_USER);
-    verify(emailBoxStorage).getEmailById(121l, TEST_USER);
+    verify(emailBoxStorage).getEmailById(121l, TEST_USER, "testEmail");
   }
 
   @Test
@@ -217,7 +219,7 @@ public class EmailBoxServiceTest {
     assertThrows(IllegalAccessException.class, () -> emailBoxService.deleteEmail(emailIds, TEST_USER));
     when(userEmailSettingService.canConnect(anyLong(), anyString())).thenReturn(true);
     Email email = email(TEST_USER);
-    when(emailBoxStorage.getEmailByMailRemoteIdAndUserId(1212l, TEST_USER, true, true, false)).thenReturn(email);
+    when(emailBoxStorage.getEmailByMailRemoteIdAndUserId(1212l, TEST_USER, null, true, true, false)).thenReturn(email);
     IMAPStore store = mock(IMAPStore.class);
     when(userEmailSettingService.connect(userEmailSetting)).thenReturn(store);
     IMAPFolder inbox = mock(IMAPFolder.class, withSettings().extraInterfaces(UIDFolder.class));
@@ -246,7 +248,7 @@ public class EmailBoxServiceTest {
     assertThrows(IllegalAccessException.class, () -> emailBoxService.archiveEmail(emailIds, TEST_USER));
     when(userEmailSettingService.canConnect(anyLong(), anyString())).thenReturn(true);
     Email email = email(TEST_USER);
-    when(emailBoxStorage.getEmailByMailRemoteIdAndUserId(1212l, TEST_USER, true, true, false)).thenReturn(email);
+    when(emailBoxStorage.getEmailByMailRemoteIdAndUserId(1212l, TEST_USER, null, true, true, false)).thenReturn(email);
     IMAPStore store = mock(IMAPStore.class);
     when(userEmailSettingService.connect(userEmailSetting)).thenReturn(store);
     IMAPFolder inbox = mock(IMAPFolder.class, withSettings().extraInterfaces(UIDFolder.class));

--- a/email-connector-services/src/test/java/org/exoplatform/emailConnector/storage/EmailBoxStorageTest.java
+++ b/email-connector-services/src/test/java/org/exoplatform/emailConnector/storage/EmailBoxStorageTest.java
@@ -51,7 +51,6 @@ import org.exoplatform.emailConnector.model.Email;
 import org.exoplatform.emailConnector.model.EmailAttachment;
 import org.exoplatform.emailConnector.model.EmailContent;
 import org.exoplatform.emailConnector.model.EmailSender;
-import org.exoplatform.social.core.manager.IdentityManager;
 
 import io.meeds.social.category.service.CategoryLinkService;
 
@@ -69,9 +68,6 @@ public class EmailBoxStorageTest {
 
   @MockBean
   private CategoryLinkService categoryLinkService;
-
-  @MockBean
-  private IdentityManager     identityManager;
 
   @Autowired
   private EmailBoxStorage     emailBoxStorage;
@@ -138,7 +134,7 @@ public class EmailBoxStorageTest {
     Email email = email("root");
     emailBoxStorage.createEmail(email);
     emailBoxStorage.markEmailAsNotRecent(1212l, "root");
-    Email updatedEmail = emailBoxStorage.getEmailByMailRemoteIdAndUserId(1212l, "root", false, false, false);
+    Email updatedEmail = emailBoxStorage.getEmailByMailRemoteIdAndUserId(1212l, "root", null, false, false, false);
     assertNotNull(updatedEmail);
     assertFalse(updatedEmail.isRecent());
   }
@@ -148,28 +144,28 @@ public class EmailBoxStorageTest {
     Email email = email("root");
     emailBoxStorage.createEmail(email);
     emailBoxStorage.updateEmailReadStatusByMailRemoteIds(List.of(1212l), "root", true);
-    Email updatedEmail = emailBoxStorage.getEmailByMailRemoteIdAndUserId(1212l, "root", false, false, false);
+    Email updatedEmail = emailBoxStorage.getEmailByMailRemoteIdAndUserId(1212l, "root", null, false, false, false);
     assertNotNull(updatedEmail);
     assertTrue(updatedEmail.isRead());
   }
 
   @Test
   void getEmailByMailRemoteIdAndUserId() {
-    Email retrievedEmail = emailBoxStorage.getEmailByMailRemoteIdAndUserId(1212l, "root", false, false, false);
+    Email retrievedEmail = emailBoxStorage.getEmailByMailRemoteIdAndUserId(1212l, "root", null, false, false, false);
     assertNull(retrievedEmail);
     Email email1 = email("root");
     emailBoxStorage.createEmail(email1);
-    retrievedEmail = emailBoxStorage.getEmailByMailRemoteIdAndUserId(1212l, "root", false, false, false);
+    retrievedEmail = emailBoxStorage.getEmailByMailRemoteIdAndUserId(1212l, "root", null, false, false, false);
     assertNotNull(retrievedEmail);
   }
 
   @Test
   void getEmailById() {
-    Email retrievedEmail = emailBoxStorage.getEmailById(2l, "root");
+    Email retrievedEmail = emailBoxStorage.getEmailById(2l, "root", null);
     assertNull(retrievedEmail);
     Email email1 = email("root");
     emailBoxStorage.createEmail(email1);
-    retrievedEmail = emailBoxStorage.getEmailById(2l, "root");
+    retrievedEmail = emailBoxStorage.getEmailById(2l, "root", null);
     assertNotNull(retrievedEmail);
   }
 


### PR DESCRIPTION

Prior to this change, "reply all" cc addresses excludes user account email instead of connected email address instead which is not coherent since user can connect an email address different from his own email address. After this commit, we ensure that "reply all" cc addresses excludes connected email address instead of user account email to make "reply all" action coherent.