### PR TITLE
fix: Fix subject and excerpt texts truncated in email list and email detail - EXO-83367

### DIFF
--- a/email-connector-services/src/main/java/org/exoplatform/emailConnector/service/EmailBoxService.java
+++ b/email-connector-services/src/main/java/org/exoplatform/emailConnector/service/EmailBoxService.java
@@ -657,8 +657,6 @@ public class EmailBoxService {
         Email email = getEmailByMailRemoteIdAndUserId(messageUid, username, false, false, false, false);
         if (email == null) {
           EmailContent emailContent = EmailConnectorUtils.getMessageContent(messageUid, message);
-          String subject = message.getSubject() != null
-              && message.getSubject().length() > 50 ? message.getSubject().substring(0, 50) + "..." : message.getSubject();
           EmailSender emailSender = message.getFrom() != null
               && message.getFrom().length != 0 ? EmailConnectorUtils.getEmailSender(message.getFrom()[0], false) : null;
           List<EmailRecipient> emailToRecipients =
@@ -683,7 +681,7 @@ public class EmailBoxService {
                                                 mailHeaderId,
                                                 username,
                                                 null,
-                                                subject,
+                                                message.getSubject(),
                                                 emailContent,
                                                 message.getReceivedDate(),
                                                 emailSender,

--- a/email-connector-services/src/main/java/org/exoplatform/emailConnector/storage/EmailBoxStorage.java
+++ b/email-connector-services/src/main/java/org/exoplatform/emailConnector/storage/EmailBoxStorage.java
@@ -156,9 +156,6 @@ public class EmailBoxStorage {
       String excerpt = null;
       if (isExcerpt) {
         excerpt = Jsoup.parse(emailBoxEntity.getBody()).text().trim();
-        if (excerpt.length() > 50) {
-          excerpt = excerpt.substring(0, 50) + "...";
-        }
       }
       String[] emailSenderParts = emailBoxEntity.getSender().split(",");
       InternetAddress emailSenderAddress = new InternetAddress(emailSenderParts[1], emailSenderParts[0]);

--- a/email-connector-services/src/main/resources/db/changelog/emailConnector-rdbms.db.changelog-master.xml
+++ b/email-connector-services/src/main/resources/db/changelog/emailConnector-rdbms.db.changelog-master.xml
@@ -182,4 +182,16 @@
       <column name="REPLY_TO" type="VARCHAR(1024)"/>
     </addColumn>
   </changeSet>
+  <changeSet author="email-connector" id="1.0.0-15">
+     <modifyDataType 
+      tableName="EMAIL_BOX" 
+      columnName="SUBJECT" 
+      newDataType="TEXT" />
+  </changeSet>
+  <changeSet author="email-connector" id="1.0.0-16" dbms="postgresql">
+    <modifyDataType 
+      tableName="EMAIL_BOX" 
+      columnName="BODY" 
+      newDataType="TEXT" />
+  </changeSet>
 </databaseChangeLog>

--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItem.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItem.vue
@@ -15,9 +15,8 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
 <template>
+  <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
   <div
-    role="button"
-    tabindex="0"
     @mouseenter="!isMobile && (isHover = true)"
     @mouseleave="!isMobile && (isHover = false)"
     @focusin="!isMobile && (isHover = true)"
@@ -78,7 +77,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         <div
           role="button"
           tabindex="0"
-          aria-label="Open email"
+          :aria-label="ariaLabel"
           @click="openDetail"
           @keydown.enter="openDetail"
           v-touch-hold="openActionMenuDrawer">
@@ -203,7 +202,10 @@ export default {
         return 'light-grey-background-color';
       }
       return '';
-    }
+    },
+    ariaLabel() {
+      return `Open email from ${this.email.sender.name} about ${this.email.subject}`;
+    },
   },
   methods: {
     openDetail() {


### PR DESCRIPTION

Prior to this change, subject and excerpt texts are returned truncated from backend which causes accessibility problems. After this commit, we ensure to return the whole subject and excerpt texts without any truncation then apply text-truncate css class which manages correclty the frontend truncation.