### PR TITLE
fix: Fix delete infomaniak email from exo mail drawer - EXO-85351

### DIFF
--- a/email-connector-services/src/main/java/org/exoplatform/emailConnector/service/EmailBoxService.java
+++ b/email-connector-services/src/main/java/org/exoplatform/emailConnector/service/EmailBoxService.java
@@ -838,13 +838,21 @@ public class EmailBoxService {
     return (BodyPart) current;
   }
 
-  @SuppressWarnings("resource")
   private IMAPFolder findTrashFolder(Store store) throws MessagingException {
     for (Folder folder : store.getDefaultFolder().listSubscribed("*")) {
       if (!(folder instanceof IMAPFolder)) {
         continue;
       }
       IMAPFolder imapFolder = (IMAPFolder) folder;
+      if (!imapFolder.exists()) {
+        continue;
+      }
+      String[] attributes = imapFolder.getAttributes();
+      for (String attr : attributes) {
+        if (attr.equalsIgnoreCase("\\Trash")) {
+          return imapFolder;
+        }
+      }
       String name = imapFolder.getFullName().toLowerCase();
       if (name.contains("trash") || name.contains("corbeille") || name.contains("deleted")) {
         return imapFolder;
@@ -853,13 +861,21 @@ public class EmailBoxService {
     return null;
   }
 
-  @SuppressWarnings("resource")
   private IMAPFolder findArchiveFolder(Store store) throws MessagingException {
     for (Folder folder : store.getDefaultFolder().listSubscribed("*")) {
-      if (!(folder instanceof IMAPFolder)){
+      if (!(folder instanceof IMAPFolder)) {
         continue;
       }
       IMAPFolder imapFolder = (IMAPFolder) folder;
+      if (!imapFolder.exists()) {
+        continue;
+      }
+      String[] attributes = imapFolder.getAttributes();
+      for (String attr : attributes) {
+        if (attr.equalsIgnoreCase("\\Archive") || attr.equalsIgnoreCase("\\All")) {
+          return imapFolder;
+        }
+      }
       String name = imapFolder.getFullName().toLowerCase();
       if (name.contains("archive") || name.contains("archivage") || name.contains("all") || name.contains("tous")) {
         return imapFolder;

--- a/email-connector-services/src/test/java/org/exoplatform/emailConnector/service/EmailBoxServiceTest.java
+++ b/email-connector-services/src/test/java/org/exoplatform/emailConnector/service/EmailBoxServiceTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import java.io.InputStream;
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -49,6 +50,7 @@ import javax.mail.Transport;
 import javax.mail.UIDFolder;
 import javax.mail.internet.MimeMessage;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
@@ -243,6 +245,8 @@ public class EmailBoxServiceTest {
     when(folder.listSubscribed("*")).thenReturn(folders);
     Message message = mock(Message.class);
     when(((UIDFolder) inbox).getMessageByUID(1212l)).thenReturn(message);
+    when(trashFolder.exists()).thenReturn(true);
+    when(trashFolder.getAttributes()).thenReturn(ArrayUtils.EMPTY_STRING_ARRAY);
     emailBoxService.deleteEmail(emailIds, TEST_USER);
     verify(emailBoxStorage).deleteEmailsByIds(anyList());
     verify(inbox).open(Folder.READ_WRITE);
@@ -272,6 +276,8 @@ public class EmailBoxServiceTest {
     when(folder.listSubscribed("*")).thenReturn(folders);
     Message message = mock(Message.class);
     when(((UIDFolder) inbox).getMessageByUID(1212l)).thenReturn(message);
+    when(archiveFolder.exists()).thenReturn(true);
+    when(archiveFolder.getAttributes()).thenReturn(ArrayUtils.EMPTY_STRING_ARRAY);
     emailBoxService.archiveEmail(emailIds, TEST_USER);
     verify(emailBoxStorage).deleteEmailsByIds(anyList());
     verify(inbox).open(Folder.READ_WRITE);


### PR DESCRIPTION
Prior to this change, infomaniak mail can not be deleted from exo mail drawer since a wrong trash folder [Gmail]/Trash is targeted for copyMessage. After this commit, we will base on IMAPFolder attributes instead of name in order to find the trash folder instead. A similar modification is always applied for archive case.