### PR TITLE
fix: Fix accessibility issues for email box list drawer - EXO-86757_EXO-86830 

### DIFF
--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItem.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItem.vue
@@ -74,12 +74,14 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         @click.stop
         @change="onSelectChange" />
       <div class="flex-grow-1 no-min-width">    
+        <!-- eslint-disable vuejs-accessibility/no-static-element-interactions -->
         <div
-          role="button"
+          class="clickable"
           tabindex="0"
           :aria-label="ariaLabel"
           @click="openDetail"
           @keydown.enter="openDetail"
+          @keydown.space.prevent="openDetail"
           v-touch-hold="openActionMenuDrawer">
           <v-list-item
             ref="mail"
@@ -104,7 +106,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
               <v-list-item-subtitle v-text="excerpt" />
             </v-list-item-content>
             <email-connector-mail-box-drawer-list-item-action-menu
-              v-if="(!isMobile && isHover && !selectMode) || menuOpen"
+              v-if="!selectMode && !isMobile"
+              :style="{
+                opacity: isHover || menuOpen ? 1 : 0,
+                pointerEvents: isHover || menuOpen ? 'auto' : 'none'
+              }"
               ref="menu"
               :email="email"
               @open="menuOpen = true"

--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemActionMenu.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemActionMenu.vue
@@ -35,7 +35,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
           :title="$t('emailConnector.mailBox.list.drawer.options.tooltip')"
           icon
           v-on="on"
-          @click.stop.prevent>
+          @click.stop.prevent
+          @keydown.enter.stop
+          @keydown.space.stop>
           <v-icon
             size="20"
             class="icon-default-color">


### PR DESCRIPTION
Prior to this change, there were accessibility issues in the email box list drawer where screen readers could not correctly access emails or trigger actions via the three-dots menu.
After this commit, the three-dots button is always present in the DOM and its visibility is controlled via CSS instead of being conditionally rendered. This ensures that screen readers and keyboard users can reliably access and interact with the email actions menu.