### PR TITLE
fix: Fix display selection background for full page mode - EXO-86452_EXO-86453

### DIFF
--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawer.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawer.vue
@@ -91,6 +91,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         hide-on-empty />
       <email-connector-mail-box-drawer-content
         :emails="emails"
+        :email="email"
         :selected-emails="selectedEmails"
         :select-mode="selectMode"
         :indeterminate="indeterminate"

--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerContent.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerContent.vue
@@ -28,6 +28,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       @click.stop />
     <email-connector-mail-box-drawer-list
       :emails="emails"
+      :current-email="email"
       :selected-emails="selectedEmails"
       :select-mode="selectMode"
       :sync-in-progress="syncInProgress"
@@ -67,6 +68,10 @@ export default {
       type: String,
       default: null,
     },
+    email: {
+      type: Object,
+      default: () => null,
+    }
   },
   computed: {
     selectedAll: {

--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerList.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerList.vue
@@ -36,7 +36,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 export default {
   data() {
     return {
-      openedEmailId: null
+      openedEmailId: this.currentEmail?.mailRemoteId,
     };
   },
   props: {
@@ -64,6 +64,10 @@ export default {
       type: String,
       default: null,
     },
+    currentEmail: {
+      type: Object,
+      default: () => null,
+    }
   }
 };
 </script>

--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemDetail.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemDetail.vue
@@ -73,6 +73,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
         :emails="filteredEmails"
         :selected-emails="selectedEmails"
         :select-mode="selectMode"
+        :email="email"
         @update:selected-emails="selectedEmails = $event"
         expanded />
     </template>


### PR DESCRIPTION

Prior to this change, when selecting an email then opening it in full-page mode the initially selected email has no selection background. Also when selecting an email in full-page mode then switching between page modes (expand and collapse), the last selected email lost its selection background. After this commit, the selected email is properly passed as a property to the email drawer list and tracked as the opened email, ensuring the selection state is correctly preserved across mode changes.