### PR TITLE
fix: Fix three-dots menu action not staying attached to activator when scrolling email list item or email detail - EXO-86917

### DIFF
--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItem.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItem.vue
@@ -25,7 +25,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       backgroundClass,
       selectMode ? 'ps-4' : 'ps-7'
     ]"
-    class="position-relative no-border overflow-hidden pt-3 pb-3 pe-4">
+    class="position-relative no-border pt-3 pb-3 pe-4">
     <div
       v-if="absolute"
       :class="[

--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemActionMenu.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemActionMenu.vue
@@ -24,7 +24,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       close-on-content-click
       offset-y
       left
-      bottom>
+      bottom
+      attach>
       <template #activator="{ on, attrs }">
         <v-btn
           v-bind="attrs"

--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemDetailActionMenu.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemDetailActionMenu.vue
@@ -22,7 +22,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       close-on-content-click
       offset-y
       left
-      bottom>
+      bottom
+      attach>
       <template #activator="{ on, attrs }">
         <v-btn
           v-bind="attrs"


### PR DESCRIPTION
Prior to this change, when opening the three-dots menu action from an email list item or email detail view then scrolling, the menu would move and no longer stay anchored to the activator element. 
This change adds the `attach` property to the `v-menu` component to ensure the menu remains correctly positioned relative to the three-dots button during scrolling.