### PR TITLE
fix: Fix unselect email while exiting it in fullpage - EXO-86450

### DIFF
--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawer.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawer.vue
@@ -297,6 +297,11 @@ export default {
       if (this.email && !this.emails.some(e => e.mailRemoteId === this.email.mailRemoteId)) {
         this.selectEmailPlaceHolder = true;
       }
+    },
+    selectEmailPlaceHolder() {
+      if (this.selectEmailPlaceHolder) {
+        this.$root.$emit('set-opened', null);
+      }
     }
   },
   methods: {
@@ -328,7 +333,7 @@ export default {
       this.close();
     },
     canDisplaySelectEmailPlaceHolder(emails) {
-      return this.expanded && (this.selectMode || this.email && emails.includes(this.email.mailRemoteId));
+      return this.expanded && (!this.email || emails.includes(this.email.mailRemoteId));
     },
     close() {
       this.stopAutoRefresh();

--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerList.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerList.vue
@@ -22,7 +22,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
       :key="email.mailRemoteId"
       :email="email"
       :opened-email-id="openedEmailId"
-      @set-opened="openedEmailId = $event"
       :emails="emails"
       :webmail-url="webmailUrl"
       :sync-in-progress="syncInProgress" 
@@ -68,6 +67,11 @@ export default {
       type: Object,
       default: () => null,
     }
-  }
+  },
+  created() {
+    this.$root.$on('set-opened', (mailRemoteId) => {
+      this.openedEmailId = mailRemoteId;
+    });
+  },
 };
 </script>

--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItem.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItem.vue
@@ -225,7 +225,7 @@ export default {
       else {
         if (this.expanded) {
           this.$root.$emit('open-email-detail-content', this.email.mailRemoteId);
-          this.$emit('set-opened', this.email.mailRemoteId);
+          this.$root.$emit('set-opened', this.email.mailRemoteId);
         }
         else {
           this.$root.$emit('open-email-detail-drawer', this.email.mailRemoteId, this.emails, this.syncInProgress, this.webmailUrl);

--- a/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemDetail.vue
+++ b/email-connector-webapps/src/main/webapp/vue-apps/email-connector-mail-box/components/drawer/EmailConnectorMailBoxDrawerListItemDetail.vue
@@ -224,6 +224,11 @@ export default {
       if (this.email && !this.filteredEmails.some(e => e.mailRemoteId === this.email.mailRemoteId)) {
         this.selectEmailPlaceHolder = true;
       }
+    },
+    selectEmailPlaceHolder() {
+      if (this.selectEmailPlaceHolder) {
+        this.$root.$emit('set-opened', null);
+      }
     }
   },
   methods: {
@@ -261,7 +266,7 @@ export default {
       this.selectedEmails = [];
     },
     canDisplaySelectEmailPlaceHolder(emails) {
-      return this.expanded && (this.selectMode || this.email && emails.includes(this.email.mailRemoteId));
+      return this.expanded && (!this.email || emails.includes(this.email.mailRemoteId));
     },
     onAbortDownloadConfirmed() {
       this.$root.$emit('abort-download-attachment', this.activeDownload.mailRemoteId, this.activeDownload.attachmentRemoteId, this.activeDownload.abortController);


### PR DESCRIPTION
Prior to this change, when marking an email as read or unread from full page mode, the select email placehodler is displayed but the email still has the selection background. After this commit, whenever the select email placeHolder is set to true we ensure to emit the set-opened event with null value of openedEmailId in order to remove the selection background.