### PR TITLE
feat: migrate statistic fields to typed collection API - EXO-87596

### DIFF
--- a/email-connector-services/src/main/java/org/exoplatform/emailConnector/listener/AnalyticsEmailListener.java
+++ b/email-connector-services/src/main/java/org/exoplatform/emailConnector/listener/AnalyticsEmailListener.java
@@ -78,9 +78,9 @@ public class AnalyticsEmailListener extends Listener<String, String> {
     statisticData.setOperation(operation);
     statisticData.setUserId(userId);
     if (event.getEventName().equals(OPEN_EMAIL) || event.getEventName().equals(ACCESS_WEBMAIL)) {
-      statisticData.addParameter("connectorName", eventData);
+      statisticData.addKeyword("connectorName", eventData);
     } else if (event.getEventName().equals(SEND_EMAIL)) {
-      statisticData.addParameter("emailType", eventData);
+      statisticData.addKeyword("emailType", eventData);
     }
     AnalyticsUtils.addStatisticData(statisticData);
   }


### PR DESCRIPTION
Replace deprecated StatisticData#addParameter usages with explicit typed APIs across product modules. Use addKeyword/addKeywords for identifiers and labels, addLong for numeric aggregation fields, and typed collection variants where needed. This makes the intended Elasticsearch mapping explicit at producer level and avoids accidental field type changes or unnecessary *_alt mapping creation.